### PR TITLE
Update value_checker

### DIFF
--- a/flask_value_checker/value_checker.py
+++ b/flask_value_checker/value_checker.py
@@ -40,7 +40,7 @@ class ValueChecker:
         check if it the parameter has been written correctly or not
         """
         if request.method in ["POST", "PUT"]:
-            return self.check_for(request.form)
+            return self.check_for({**request.form, **request.args})
         else:
             return self.check_for(request.args)
 

--- a/tests/test_simple_flask.py
+++ b/tests/test_simple_flask.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from flask import Flask, request
 from helper import Invigilator
 
@@ -35,6 +36,31 @@ invigilator = Invigilator()
 def popo():
     form = request.form
     return f"hi {form['name']} of {form['place']}, who likes {form['animal']}s and {form['thing']}s"
+
+
+@app.route("/upload_file", methods=["POST"])
+@invigilator.check(
+    ["POST"],
+    """
+    param1 : str/accept(['test1','test2'])
+    """,
+)
+def upload_file():
+    file = request.files["file"]
+    args = request.args
+    return f"param1 {args['param1']} filename {file.filename} file contents {file.read().decode()}"
+
+
+def test_upload_file():
+    with app.test_client() as client:
+        rv = client.post(
+            "/upload_file?param1=test1",
+            content_type="multipart/form-data",
+            data={"file": (BytesIO(b"sample"), "sample.txt")},
+        )
+
+        assert rv.status_code == 200
+        assert rv.data == b"param1 test1 filename sample.txt file contents sample"
 
 
 def test_simple_flask():


### PR DESCRIPTION
It was previously not possible to have query parameters checked when
POSTing form-data, because you can't POST both data and form input.

This PR makes it possible to continue validating query parameters along
requests that include with form-data